### PR TITLE
fix: getWithIdxAggregate if len(result)==0, return RecordNotFound

### DIFF
--- a/ultra_table.go
+++ b/ultra_table.go
@@ -603,6 +603,9 @@ func (u *UltraTable) getWithIdxIntersection(conditions map[string]interface{}) (
 			result = append(result, u.table[k])
 		}
 	}
+	if len(result) == 0 {
+		return nil, RecordNotFound
+	}
 	return result, nil
 }
 

--- a/ultra_table_test.go
+++ b/ultra_table_test.go
@@ -186,7 +186,7 @@ func TestUslice(t *testing.T) {
 				"StockCode": "800",
 				"Currency":  "USD",
 			})
-			So(err, ShouldBeNil)
+			So(RecordNotFound == err, ShouldBeTrue)
 			So(len(list), ShouldEqual, 0)
 
 			list, err = Uslice.GetWithIdxIntersection(map[string]interface{}{
@@ -345,7 +345,7 @@ func TestUslice(t *testing.T) {
 				"Name": "d",
 				"Age":  20,
 			})
-			So(err, ShouldBeNil)
+			So(RecordNotFound == err, ShouldBeTrue)
 			So(len(list), ShouldEqual, 0)
 		})
 	})


### PR DESCRIPTION
merge 